### PR TITLE
일부 오류를 수정했습니다

### DIFF
--- a/src/main/kotlin/com/github/noonmaru/regions/internal/AreaImpl.kt
+++ b/src/main/kotlin/com/github/noonmaru/regions/internal/AreaImpl.kt
@@ -207,11 +207,15 @@ abstract class AreaImpl(
     }
 
     override fun testPermission(player: Player, permission: Permission): Boolean {
-        return getOrComputePlayerPermissions(player).contains(permission)
+        return getOrComputePlayerPermissions(player).let {
+            Permission.ADMINISTRATION in it || permission in it
+        }
     }
 
     override fun testPermissions(player: Player, permissions: Collection<Permission>): Boolean {
-        return getOrComputePlayerPermissions(player).containsAll(permissions)
+        return getOrComputePlayerPermissions(player).let {
+            Permission.ADMINISTRATION in it || it.containsAll(permissions)
+        }
     }
 
     internal open fun resetPlayerPermissions(player: Player) {
@@ -241,8 +245,12 @@ abstract class AreaImpl(
         private const val CFG_MEMBERS = "members"
     }
 
+    protected fun getAllPermissionsForMember(member: MemberImpl?): PermissionSet {
+        return PermissionSet(member?._permissions?.let { it.rawElements or _publicRole._permissions.rawElements } ?: _publicRole._permissions.rawElements)
+    }
+
     protected open fun computePlayerPermissions(player: Player): PermissionSet {
-        return _memberByUser[(manager.getUser(player))]?._permissions ?: _publicRole._permissions
+        return getAllPermissionsForMember(_memberByUser[(manager.getUser(player))])
     }
 
     internal fun setMustBeSave() {

--- a/src/main/kotlin/com/github/noonmaru/regions/internal/RegionImpl.kt
+++ b/src/main/kotlin/com/github/noonmaru/regions/internal/RegionImpl.kt
@@ -210,7 +210,7 @@ class RegionImpl(
         }
 
         val member = getMember(user)
-        val memberPermissions = member?._permissions ?: publicRole._permissions
+        val memberPermissions = getAllPermissionsForMember(member)
 
         permissions.or(memberPermissions)
 


### PR DESCRIPTION
- `Permission.ADMINISTRATION`의 효과가 없었습니다. 관리자 권한이 있으면 모든 권한을 가지는 것처럼 동작해야 합니다.
- 특정 Region의 members 목록에 올라가 있는 사용자에게는 해당 영역의 publicRole이 적용되지 않았습니다.

이 수정이 원래 의도하셨던 동작인지는 잘 모르겠네요. 제 생각에 이렇게 하는게 맞지 않나 싶어서 수정해 보았습니다.